### PR TITLE
delete the multi-including in proj.pro

### DIFF
--- a/proj.pro
+++ b/proj.pro
@@ -28,10 +28,6 @@ SOURCES += \
         mainwindow.cpp \
         xibridge.cpp \
         editor.cpp \
-    editor.cpp \
-    main.cpp \
-    mainwindow.cpp \
-    xibridge.cpp \
     ui/editorview.cpp \
     ui/editormodel.cpp \
     ui/cell.cpp \
@@ -46,9 +42,6 @@ HEADERS += \
         mainwindow.h \
         xibridge.h \
         editor.h \
-    editor.h \
-    mainwindow.h \
-    xibridge.h \
     ui/editorview.h \
     ui/editormodel.h \
     ui/cell.h \


### PR DESCRIPTION
## .pro file
the SOURCES and HEADER had included the following files twice, causing **mutilple definition** error when compiling 
```
main.cpp\ mainwindow.cpp\ xibridge.cpp\ editor.cpp
mainwindow.h\ xibridge.h\ editor.h
```

## .pro文件
 SOURCES 和 HEADER属性将以上文件添加了两次，造成**重复定义**编译错误